### PR TITLE
修复详情页截图占位图大小显示问题

### DIFF
--- a/iAppStore/Models/AppDetail.swift
+++ b/iAppStore/Models/AppDetail.swift
@@ -111,6 +111,20 @@ struct AppDetail: Codable {
         String(format: "%.1f", averageUserRating)
     }
     
+    /// 截图展示大小
+    var screenShotSize: CGSize {
+        let width = 200.0
+        let defaultSize = CGSize(width: width, height: width)
+        let url = screenshotUrls?.first ?? ""
+        let size = url.imageAppleSize()
+        guard size != CGSize.zero else {
+            return defaultSize
+        }
+
+        let height = Double(size.height) / Double(size.width) * width
+        return CGSize(width: width, height: height);
+    }
+    
     static func getNewModel(_ artistId: String) -> AppDetail {
         return AppDetail(advisories: nil, appletvScreenshotUrls: nil, artistId: Int(artistId)!, artistName: "", artistViewUrl: nil, artworkUrl100: nil, artworkUrl512: "", artworkUrl60: "", averageUserRating: 0, averageUserRatingForCurrentVersion: 0, bundleId: "", contentAdvisoryRating: "", currency: "", currentVersionReleaseDate: "", description: "", features: [], fileSizeBytes: nil, formattedPrice: nil, genreIds: [], genres: [], ipadScreenshotUrls: [], isGameCenterEnabled: false, isVppDeviceBasedLicensingEnabled: false, kind: "", languageCodesISO2A: [], minimumOsVersion: "", price: 0, primaryGenreId: 0, primaryGenreName: "", releaseDate: "", releaseNotes: nil, screenshotUrls:nil, sellerName: "", sellerUrl: nil, supportedDevices: [], trackCensoredName: "", trackContentRating: "", trackId: 0, trackName: "", trackViewUrl: "", userRatingCount: 0, userRatingCountForCurrentVersion: 0, version: "", wrapperType: "")
     }

--- a/iAppStore/Shared/extensions/Strings.swift
+++ b/iAppStore/Shared/extensions/Strings.swift
@@ -12,27 +12,40 @@ import CryptoKit
 
 extension String {
     
-    
-    /// 处理苹果图片尺寸
+    /// 获取苹果缩略图尺寸
     /// 类似： https://is1-ssl.mzstatic.com/image/thumb/PurpleSource124/v4/16/0a/18/160a1889-5d30-9ef1-09fd-cacd97f5f0bd/96e99d1b-6a47-4c78-a570-4b7682c5c9df_img5_5_0_zh-Hans.png/392x696bb.png
-    /// - Parameter scale: 缩放比例
-    /// - Returns: 缩放后的 url
-    public func imageAppleScale(_ scale: Double = UIScreen.main.scale) -> String {
+    /// - Returns: 缩略图 Size
+    public func imageAppleSize() -> CGSize {
   
         if let url = URL(string: self) {
             let component = url.lastPathComponent
             let splits = component.components(separatedBy: CharacterSet.decimalDigits.inverted)
             if splits.count > 1, let fSize = splits.first, let lSize = splits.dropFirst().first {
                 if let fdSize = Double(fSize),  let ldSize = Double(lSize) {
-                    let newfSize = String(Int(fdSize * scale))
-                    let newlSize = String(Int(ldSize * scale))
-                    let newComponent = component
-                            .replacingOccurrences(of: fSize, with: newfSize)
-                            .replacingOccurrences(of: lSize, with: newlSize)
-                    let newUrl = url.deletingLastPathComponent().appendingPathComponent(newComponent).relativeString
-                    return newUrl
+                    let size = CGSize(width: fdSize, height: ldSize)
+                    return size
                 }
             }
+        }
+        
+        return CGSize.zero
+    }
+    
+    /// 处理苹果图片尺寸
+    /// 类似： https://is1-ssl.mzstatic.com/image/thumb/PurpleSource124/v4/16/0a/18/160a1889-5d30-9ef1-09fd-cacd97f5f0bd/96e99d1b-6a47-4c78-a570-4b7682c5c9df_img5_5_0_zh-Hans.png/392x696bb.png
+    /// - Parameter scale: 缩放比例
+    /// - Returns: 缩放后的 url
+    public func imageAppleScale(_ scale: Double = UIScreen.main.scale) -> String {
+        if let url = URL(string: self) {
+            let component = url.lastPathComponent
+            let size = imageAppleSize()
+            let newfSize = String(Int(size.width * scale))
+            let newlSize = String(Int(size.height * scale))
+            let newComponent = component
+                .replacingOccurrences(of: String(Int(size.width)), with: newfSize)
+                .replacingOccurrences(of: String(Int(size.height)), with: newlSize)
+            let newUrl = url.deletingLastPathComponent().appendingPathComponent(newComponent).relativeString
+            return newUrl
         }
         
         return self

--- a/iAppStore/components/rankLists/AppDetailContentView.swift
+++ b/iAppStore/components/rankLists/AppDetailContentView.swift
@@ -184,7 +184,7 @@ struct AppDetailScreenShowView: View {
             
             if appModel.app != nil && appModel.app!.isSupportiPhone {
                 
-                AppDetailScreenShotView(screenshotUrls: appModel.app?.screenshotUrls, imageWidth: 200)
+                AppDetailScreenShotView(screenshotUrls: appModel.app?.screenshotUrls, imageSize: appModel.app?.screenShotSize)
                 
                 HStack {
                     Image(systemName: "iphone").foregroundColor(.gray).font(.body)
@@ -213,7 +213,7 @@ struct AppDetailScreenShowView: View {
             if (appModel.app != nil && extendiPadShot)
                 || (appModel.app != nil && !appModel.app!.isSupportiPhone && appModel.app!.isSupportiPad)
             {
-                AppDetailScreenShotView(screenshotUrls: appModel.app?.ipadScreenshotUrls, imageWidth: 300)
+                AppDetailScreenShotView(screenshotUrls: appModel.app?.ipadScreenshotUrls, imageSize: appModel.app?.screenShotSize)
                 
                 HStack {
                     Image(systemName: "ipad").foregroundColor(.gray).font(.body)
@@ -234,7 +234,7 @@ struct AppDetailScreenShowView: View {
 struct AppDetailScreenShotView: View {
     
     var screenshotUrls: [String]?
-    var imageWidth: CGFloat = 200
+    var imageSize: CGSize?
     @State private var selectedShot: Bool = false
     @State private var selectedImgUrl: String?
     
@@ -255,14 +255,17 @@ struct AppDetailScreenShotView: View {
                                     .resizable()
                                     .scaledToFit()
                                     .cornerRadius(11)
-                                    .frame(width: imageWidth)
+                                    .frame(width: imageSize?.width)
                             },
                             image: {
                                 $0.resizable()
                                     .scaledToFit()
                                     .cornerRadius(11)
-                                    .overlay(RoundedRectangle(cornerRadius: 11).stroke(Color.gray, lineWidth: 0.1))
-                                    .frame(width: imageWidth)
+                                    .overlay(RoundedRectangle(cornerRadius: 11)
+                                        .stroke(Color.gray, lineWidth: 0.1)
+                                        .frame(width: imageSize?.width, height: imageSize?.height))
+                                    .frame(width: imageSize?.width, height: imageSize?.height)
+
                             }
                         )
                     }


### PR DESCRIPTION
修复前：
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-31 at 08 05 05](https://user-images.githubusercontent.com/9426832/217114973-98999048-14e7-487c-9586-799303d7f3fc.png)

修复后：
![image](https://user-images.githubusercontent.com/9426832/217115165-7ae453c0-92f3-4565-bb9c-62754c3c4a60.png)
